### PR TITLE
launchEvery___ and onNext___

### DIFF
--- a/android-lifecycle-runtime/src/main/java/dispatch/android/LifecycleCoroutineScope.kt
+++ b/android-lifecycle-runtime/src/main/java/dispatch/android/LifecycleCoroutineScope.kt
@@ -72,8 +72,8 @@ class LifecycleCoroutineScope(
    * }
    *```
    */
-  fun <T> launchEveryCreate(
-    block: suspend CoroutineScope.() -> T
+  fun launchEveryCreate(
+    block: suspend CoroutineScope.() -> Unit
   ): Job = launchEvery(Lifecycle.State.CREATED, block)
 
   /**
@@ -101,8 +101,8 @@ class LifecycleCoroutineScope(
    * }
    *```
    */
-  fun <T> launchEveryStart(
-    block: suspend CoroutineScope.() -> T
+  fun launchEveryStart(
+    block: suspend CoroutineScope.() -> Unit
   ): Job = launchEvery(Lifecycle.State.STARTED, block)
 
   /**
@@ -130,8 +130,8 @@ class LifecycleCoroutineScope(
    * }
    *```
    */
-  fun <T> launchEveryResume(
-    block: suspend CoroutineScope.() -> T
+  fun launchEveryResume(
+    block: suspend CoroutineScope.() -> Unit
   ): Job = launchEvery(Lifecycle.State.RESUMED, block)
 
 }

--- a/android-lifecycle-runtime/src/main/java/dispatch/android/LifecycleCoroutineScope.kt
+++ b/android-lifecycle-runtime/src/main/java/dispatch/android/LifecycleCoroutineScope.kt
@@ -43,7 +43,7 @@ val LifecycleOwner.lifecycleScope: LifecycleCoroutineScope
  * that state again will start a new [Job].
  */
 class LifecycleCoroutineScope(
-  val lifecycle: Lifecycle,
+  internal val lifecycle: Lifecycle,
   private val coroutineScope: MainImmediateCoroutineScope
 ) : MainImmediateCoroutineScope by coroutineScope {
 
@@ -63,7 +63,7 @@ class LifecycleCoroutineScope(
    * class SomeFragment : Fragment {
    *
    *   init {
-   *     lifeycleScope.launchWhileCreated {
+   *     lifecycleScope.launchWhileCreated {
    *       viewModel.someFlow.collect {
    *         printLn("new value --> $it")
    *       }
@@ -72,9 +72,9 @@ class LifecycleCoroutineScope(
    * }
    *```
    */
-  fun <T> launchWhileCreated(
+  fun <T> launchEveryCreate(
     block: suspend CoroutineScope.() -> T
-  ): Job = launchOnlyWhile(Lifecycle.State.CREATED, block)
+  ): Job = launchEvery(Lifecycle.State.CREATED, block)
 
   /**
    * Lifecycle-aware function for launching a coroutine any time the [Lifecycle.State]
@@ -92,7 +92,7 @@ class LifecycleCoroutineScope(
    * class SomeFragment : Fragment {
    *
    *   init {
-   *     lifeycleScope.launchWhileStarted {
+   *     lifecycleScope.launchWhileStarted {
    *       viewModel.someFlow.collect {
    *         printLn("new value --> $it")
    *       }
@@ -101,9 +101,9 @@ class LifecycleCoroutineScope(
    * }
    *```
    */
-  fun <T> launchWhileStarted(
+  fun <T> launchEveryStart(
     block: suspend CoroutineScope.() -> T
-  ): Job = launchOnlyWhile(Lifecycle.State.STARTED, block)
+  ): Job = launchEvery(Lifecycle.State.STARTED, block)
 
   /**
    * Lifecycle-aware function for launching a coroutine any time the [Lifecycle.State]
@@ -121,7 +121,7 @@ class LifecycleCoroutineScope(
    * class SomeFragment : Fragment {
    *
    *   init {
-   *     lifeycleScope.launchWhileResumed {
+   *     lifecycleScope.launchWhileResumed {
    *       viewModel.someFlow.collect {
    *         printLn("new value --> $it")
    *       }
@@ -130,8 +130,8 @@ class LifecycleCoroutineScope(
    * }
    *```
    */
-  fun <T> launchWhileResumed(
+  fun <T> launchEveryResume(
     block: suspend CoroutineScope.() -> T
-  ): Job = launchOnlyWhile(Lifecycle.State.RESUMED, block)
+  ): Job = launchEvery(Lifecycle.State.RESUMED, block)
 
 }

--- a/android-lifecycle-runtime/src/main/java/dispatch/android/LifecycleSuspendExt.kt
+++ b/android-lifecycle-runtime/src/main/java/dispatch/android/LifecycleSuspendExt.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dispatch.android
+
+import androidx.lifecycle.*
+import dispatch.android.internal.*
+import kotlinx.coroutines.*
+
+/**
+ * Executes [block] one time, the next time the [Lifecycle]'s state is at least [Lifecycle.State.CREATED].
+ *
+ * If the lifecycle is already in this state, [block] will be executed immediately.
+ *
+ * @see [LifecycleCoroutineScope.launchEveryCreate] for repeating behavior.
+ */
+suspend fun <T> LifecycleOwner.onNextCreate(
+  block: suspend CoroutineScope.() -> T
+): T? = lifecycle.onNext(Lifecycle.State.CREATED, block)
+
+/**
+ * Executes [block] one time, the next time the [Lifecycle]'s state is at least [Lifecycle.State.CREATED].
+ *
+ * If the lifecycle is already in this state, [block] will be executed immediately.
+ *
+ * @see [LifecycleCoroutineScope.launchEveryCreate] for repeating behavior.
+ */
+suspend fun <T> Lifecycle.onNextCreate(
+  block: suspend CoroutineScope.() -> T
+): T? = onNext(Lifecycle.State.CREATED, block)
+
+/**
+ * Executes [block] one time, the next time the [Lifecycle]'s state is at least [Lifecycle.State.STARTED].
+ *
+ * If the lifecycle is already in this state, [block] will be executed immediately.
+ *
+ * @see [LifecycleCoroutineScope.launchEveryStart] for repeating behavior.
+ */
+suspend fun <T> LifecycleOwner.onNextStart(
+  block: suspend CoroutineScope.() -> T
+): T? = lifecycle.onNext(Lifecycle.State.STARTED, block)
+
+/**
+ * Executes [block] one time, the next time the [Lifecycle]'s state is at least [Lifecycle.State.STARTED].
+ *
+ * If the lifecycle is already in this state, [block] will be executed immediately.
+ *
+ * @see [LifecycleCoroutineScope.launchEveryStart] for repeating behavior.
+ */
+suspend fun <T> Lifecycle.onNextStart(
+  block: suspend CoroutineScope.() -> T
+): T? = onNext(Lifecycle.State.STARTED, block)
+
+/**
+ * Executes [block] one time, the next time the [Lifecycle]'s state is at least [Lifecycle.State.RESUMED].
+ *
+ * If the lifecycle is already in this state, [block] will be executed immediately.
+ *
+ * @see [LifecycleCoroutineScope.launchEveryResume] for repeating behavior.
+ */
+suspend fun <T> LifecycleOwner.onNextResume(
+  block: suspend CoroutineScope.() -> T
+): T? = lifecycle.onNext(Lifecycle.State.RESUMED, block)
+
+/**
+ * Executes [block] one time, the next time the [Lifecycle]'s state is at least [Lifecycle.State.RESUMED].
+ *
+ * If the lifecycle is already in this state, [block] will be executed immediately.
+ *
+ * @see [LifecycleCoroutineScope.launchEveryResume] for repeating behavior.
+ */
+suspend fun <T> Lifecycle.onNextResume(
+  block: suspend CoroutineScope.() -> T
+): T? = onNext(Lifecycle.State.RESUMED, block)
+

--- a/android-lifecycle-runtime/src/main/java/dispatch/android/internal/LifecycleScopeExt.kt
+++ b/android-lifecycle-runtime/src/main/java/dispatch/android/internal/LifecycleScopeExt.kt
@@ -23,30 +23,62 @@ import dispatch.extensions.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
+import java.util.concurrent.atomic.*
 
 @Suppress("EXPERIMENTAL_API_USAGE")
-internal fun <T> LifecycleCoroutineScope.launchOnlyWhile(
+internal suspend fun <T> Lifecycle.onNext(
   minimumState: Lifecycle.State, block: suspend CoroutineScope.() -> T
-): Job = callbackFlow<Boolean> {
+): T? {
 
-  val observer = LifecycleEventObserver { _, _ ->
+  var result: T? = null
+  val stateReached = AtomicBoolean(false)
 
-    // send true if the state is high enough, false if not
-    sendBlocking(lifecycle.currentState.isAtLeast(minimumState))
-
-    // if screen is destroyed, send the last value to cancel the last block and then close the channel
-    if (lifecycle.currentState == Lifecycle.State.DESTROYED) {
-      channel.close()
-    }
+  try {
+    // suspend until the lifecycle's flow has reached the minimum state, then move on
+    eventFlow(minimumState)
+      .onEachLatest { stateIsHighEnough ->
+        if (stateIsHighEnough) {
+          stateReached.compareAndSet(false, true)
+          coroutineScope { result = block() }
+          throw FlowCancellationException()
+        }
+      }
+      .collectUntil { stateIsHighEnough ->
+        !stateIsHighEnough && stateReached.get()
+      }
+  } catch (e: FlowCancellationException) {
+    // do nothing
   }
 
-  lifecycle.addObserver(observer)
-
-  // When the channel is closed, remove the observer.
-  awaitClose { lifecycle.removeObserver(observer) }
+  return result
 }
-  // Don't send [true, true] since the second true would cancel the already-active block.
-  .distinctUntilChanged()
+
+@Suppress("EXPERIMENTAL_API_USAGE")
+internal fun LifecycleCoroutineScope.launchNext(
+  minimumState: Lifecycle.State, block: suspend CoroutineScope.() -> Unit
+): Job = launch {
+  lifecycle.eventFlow(minimumState)
+    // Respond to every change in the Flow, cancelling execution of the previous onEach if it hasn't already finished.
+    // This is responsible for cancelling Jobs when a Lifecycle.State dips below the threshold,
+    // such as going from CREATED to DESTROYED in launchWhileCreated().
+    .onEachLatest { active ->
+
+      if (active) {
+        // Create a CoroutineScope which is tied to the receiver LifecycleCoroutineScope.
+        // This new CoroutineScope will be automatically cancelled when the parent scope is cancelled,
+        // or when onEachLatest executes for a new value.
+        coroutineScope { block() }
+      }
+    }
+    // Use the receiver LifecycleCoroutineScope's Job, but ensure that this coroutine is launch immediately from Main.
+    // Lifecycle observers can only be added/removed from Main.
+    .collectUntil { true }
+}
+
+@Suppress("EXPERIMENTAL_API_USAGE")
+internal fun LifecycleCoroutineScope.launchEvery(
+  minimumState: Lifecycle.State, block: suspend CoroutineScope.() -> Unit
+): Job = lifecycle.eventFlow(minimumState)
   // Respond to every change in the Flow, cancelling execution of the previous onEach if it hasn't already finished.
   // This is responsible for cancelling Jobs when a Lifecycle.State dips below the threshold,
   // such as going from CREATED to DESTROYED in launchWhileCreated().
@@ -61,4 +93,36 @@ internal fun <T> LifecycleCoroutineScope.launchOnlyWhile(
   }
   // Use the receiver LifecycleCoroutineScope's Job, but ensure that this coroutine is launch immediately from Main.
   // Lifecycle observers can only be added/removed from Main.
-  .launchIn(this + dispatcherProvider.mainImmediate)
+  .launchIn(this)
+
+/**
+ * Distinct Flow representing `true` if the state is at or above [minimumState], and `false` when below.
+ *
+ * The flow ends when the lifecycle is [destroyed][Lifecycle.State.DESTROYED]
+ */
+@Suppress("EXPERIMENTAL_API_USAGE")
+internal fun Lifecycle.eventFlow(
+  minimumState: Lifecycle.State
+): Flow<Boolean> = callbackFlow<Boolean> {
+
+  val observer = LifecycleEventObserver { _, _ ->
+
+    // send true if the state is high enough, false if not
+    sendBlocking(currentState.isAtLeast(minimumState))
+
+    // if lifecycle is destroyed, send the last value to cancel the last block and then close the channel
+    if (currentState == Lifecycle.State.DESTROYED) {
+      channel.close()
+    }
+  }
+
+  addObserver(observer)
+
+  // When the channel is closed, remove the observer.
+  awaitClose { removeObserver(observer) }
+}
+  .flowOnMainImmediate()
+  // Don't send [true, true] since the second true would cancel the already-active block.
+  .distinctUntilChanged()
+
+internal class FlowCancellationException : CancellationException("Flow was aborted")

--- a/android-lifecycle-runtime/src/test/java/dispatch/android/LifecycleCoroutineScopeTest.kt
+++ b/android-lifecycle-runtime/src/test/java/dispatch/android/LifecycleCoroutineScopeTest.kt
@@ -44,34 +44,34 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
   }
 
   @Nested
-  inner class `launch only created` {
+  inner class `launch every create` {
 
     @Test
-    fun `added lambda should immediately execute if already created`() = runBlocking {
+    fun `block should immediately execute if already created`() = runBlocking {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
 
       var executed = false
 
-      scope.launchWhileCreated { executed = true }
+      scope.launchEveryCreate { executed = true }
 
       executed shouldBe true
     }
 
     @Test
-    fun `added lambda should not immediately execute if screen is not created`() = runBlocking {
+    fun `block should not immediately execute if screen is not created`() = runBlocking {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
       var executed = false
 
-      scope.launchWhileCreated { executed = true }
+      scope.launchEveryCreate { executed = true }
 
       executed shouldBe false
     }
 
     @Test
-    fun `added lambda should stop when screen is destroyed`() = runBlocking {
+    fun `block should stop when screen is destroyed`() = runBlocking {
 
       val input = Channel<Int>()
       val output = mutableListOf<Int>()
@@ -79,7 +79,7 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
 
-      scope.launchWhileCreated {
+      scope.launchEveryCreate {
         input.consumeAsFlow()
           .onCompletion { completed = true }
           .collect { output.add(it) }
@@ -97,23 +97,22 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
   }
 
   @Nested
-  inner class `launch only started` {
+  inner class `launch every start` {
 
     @Test
-    fun `added lambda should immediately execute if already started`() = runBlocking {
+    fun `block should immediately execute if already started`() = runBlocking {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
       var executed = false
 
-
-      scope.launchWhileStarted { executed = true }
+      scope.launchEveryStart { executed = true }
 
       executed shouldBe true
     }
 
     @Test
-    fun `added lambda should not immediately execute if screen is not started`() = runBlocking {
+    fun `block should not immediately execute if screen is not started`() = runBlocking {
 
       Lifecycle.Event.values()
         .filter {
@@ -130,15 +129,14 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
 
           var executed = false
 
-
-          scope.launchWhileStarted { executed = true }
+          scope.launchEveryStart { executed = true }
 
           executed shouldBe false
         }
     }
 
     @Test
-    fun `added lambda should stop when screen is stopped`() = runBlocking {
+    fun `block should stop when screen is stopped`() = runBlocking {
 
       val input = Channel<Int>()
       val output = mutableListOf<Int>()
@@ -146,8 +144,7 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
-
-      scope.launchWhileStarted {
+      scope.launchEveryStart {
         input.consumeAsFlow()
           .onCompletion { completed = true }
           .collect { output.add(it) }
@@ -165,23 +162,22 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
   }
 
   @Nested
-  inner class `launch only resumed` {
+  inner class `launch every resume` {
 
     @Test
-    fun `added lambda should immediately execute if already resumed`() = runBlocking {
+    fun `block should immediately execute if already resumed`() = runBlocking {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
 
       var executed = false
 
-
-      scope.launchWhileResumed { executed = true }
+      scope.launchEveryResume { executed = true }
 
       executed shouldBe true
     }
 
     @Test
-    fun `added lambda should not immediately execute if screen is not resumed`() = runBlocking {
+    fun `block should not immediately execute if screen is not resumed`() = runBlocking {
 
       Lifecycle.Event.values()
         .filter {
@@ -200,15 +196,14 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
 
           var executed = false
 
-
-          scope.launchWhileResumed { executed = true }
+          scope.launchEveryResume { executed = true }
 
           executed shouldBe false
         }
     }
 
     @Test
-    fun `added lambda should stop when screen is paused`() = runBlocking {
+    fun `block should stop when screen is paused`() = runBlocking {
 
       val input = Channel<Int>()
       val output = mutableListOf<Int>()
@@ -216,7 +211,7 @@ class LifecycleCoroutineScopeTest : CoroutineTest {
 
       lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
 
-      scope.launchWhileResumed {
+      scope.launchEveryResume {
         input.consumeAsFlow()
           .onCompletion { completed = true }
           .collect { output.add(it) }

--- a/android-lifecycle-runtime/src/test/java/dispatch/android/OnNextCreateTest.kt
+++ b/android-lifecycle-runtime/src/test/java/dispatch/android/OnNextCreateTest.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2020 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package  dispatch.android
+
+import androidx.lifecycle.*
+import dispatch.core.test.*
+import dispatch.internal.test.*
+import io.kotlintest.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.*
+import org.junit.jupiter.api.*
+
+@FlowPreview
+@ExperimentalCoroutinesApi
+class OnNextCreateTest : BaseTest(), CoroutineTest {
+
+  override lateinit var testScope: TestProvidedCoroutineScope
+
+  lateinit var lifecycleOwner: LifecycleOwner
+  lateinit var lifecycle: LifecycleRegistry
+
+  @BeforeEach
+  fun beforeEach() {
+
+    lifecycleOwner = LifecycleOwner { lifecycle }
+    lifecycle = LifecycleRegistry(lifecycleOwner)
+  }
+
+  @Nested
+  inner class `Lifecycle version` {
+
+    @Test
+    fun `block should immediately execute if already created`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      var executed = false
+
+      launch { lifecycle.onNextCreate { executed = true } }
+
+      executed shouldBe true
+    }
+
+    @Test
+    fun `block should not immediately execute if lifecycle is not created`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      var executed = false
+
+      val job = launch { lifecycle.onNextCreate { executed = true } }
+
+      executed shouldBe false
+
+      job.cancelAndJoin()
+    }
+
+    @Test
+    fun `block should stop when lifecycle is destroyed`() = runBlockingTest {
+
+      val input = Channel<Int>()
+      val output = mutableListOf<Int>()
+      var completed = false
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      launch {
+        lifecycle.onNextCreate {
+          input.consumeAsFlow()
+            .onCompletion { completed = true }
+            .collect { output.add(it) }
+        }
+      }
+
+      input.send(1)
+      input.send(2)
+      input.send(3)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      output shouldBe listOf(1, 2, 3)
+      completed shouldBe true
+    }
+
+    @Test
+    fun `block should not execute twice when lifecycle is created twice`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      lifecycle.onNextCreate { expect(1) }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      expect(2)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      finish(3)
+    }
+
+    @Test
+    fun `block should return value if allowed to complete`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      val result = lifecycle.onNextCreate { true }
+
+      result shouldBe true
+    }
+
+    @Test
+    fun `block should return null if not allowed to complete`() = runBlockingTest {
+
+      val lock = Mutex(locked = true)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      val resultDeferred = async {
+        lifecycle.onNextCreate {
+          lock.withLock {
+            // unreachable
+            true
+          }
+        }
+      }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      resultDeferred.await() shouldBe null
+    }
+  }
+
+  @Nested
+  inner class `LifecycleOwner version` {
+
+    @Test
+    fun `block should immediately execute if already created`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      var executed = false
+
+      launch { lifecycle.onNextCreate { executed = true } }
+
+      executed shouldBe true
+    }
+
+    @Test
+    fun `block should not immediately execute if lifecycle is not created`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      var executed = false
+
+      val job = launch { lifecycle.onNextCreate { executed = true } }
+
+      executed shouldBe false
+
+      job.cancelAndJoin()
+    }
+
+    @Test
+    fun `block should stop when lifecycle is destroyed`() = runBlockingTest {
+
+      val input = Channel<Int>()
+      val output = mutableListOf<Int>()
+      var completed = false
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      launch {
+        lifecycle.onNextCreate {
+          input.consumeAsFlow()
+            .onCompletion { completed = true }
+            .collect { output.add(it) }
+        }
+      }
+
+      input.send(1)
+      input.send(2)
+      input.send(3)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      output shouldBe listOf(1, 2, 3)
+      completed shouldBe true
+    }
+
+    @Test
+    fun `block should not execute twice when lifecycle is created twice`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      lifecycle.onNextCreate { expect(1) }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      expect(2)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      finish(3)
+    }
+
+    @Test
+    fun `block should return value if allowed to complete`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      val result = lifecycle.onNextCreate { true }
+
+      result shouldBe true
+    }
+
+    @Test
+    fun `block should return null if not allowed to complete`() = runBlockingTest {
+
+      val lock = Mutex(locked = true)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+      val resultDeferred = async {
+        lifecycle.onNextCreate {
+          lock.withLock {
+            // unreachable
+            true
+          }
+        }
+      }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+      resultDeferred.await() shouldBe null
+    }
+  }
+}

--- a/android-lifecycle-runtime/src/test/java/dispatch/android/OnNextResumeTest.kt
+++ b/android-lifecycle-runtime/src/test/java/dispatch/android/OnNextResumeTest.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2020 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package  dispatch.android
+
+import androidx.lifecycle.*
+import dispatch.core.test.*
+import dispatch.internal.test.*
+import io.kotlintest.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.*
+import org.junit.jupiter.api.*
+
+@FlowPreview
+@ExperimentalCoroutinesApi
+class OnNextResumeTest : BaseTest(), CoroutineTest {
+
+  override lateinit var testScope: TestProvidedCoroutineScope
+
+  lateinit var lifecycleOwner: LifecycleOwner
+  lateinit var lifecycle: LifecycleRegistry
+
+  @BeforeEach
+  fun beforeEach() {
+
+    lifecycleOwner = LifecycleOwner { lifecycle }
+    lifecycle = LifecycleRegistry(lifecycleOwner)
+  }
+
+  @Nested
+  inner class `Lifecycle version` {
+
+    @Test
+    fun `block should immediately execute if already resumed`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      var executed = false
+
+      launch { lifecycle.onNextResume { executed = true } }
+
+      executed shouldBe true
+    }
+
+    @Test
+    fun `block should not immediately execute if lifecycle is not resumed`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      var executed = false
+
+      val job = launch { lifecycle.onNextResume { executed = true } }
+
+      executed shouldBe false
+
+      job.cancelAndJoin()
+    }
+
+    @Test
+    fun `block should pause when lifecycle is destroyed`() = runBlockingTest {
+
+      val input = Channel<Int>()
+      val output = mutableListOf<Int>()
+      var completed = false
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      launch {
+        lifecycle.onNextResume {
+          input.consumeAsFlow()
+            .onCompletion { completed = true }
+            .collect { output.add(it) }
+        }
+      }
+
+      input.send(1)
+      input.send(2)
+      input.send(3)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      output shouldBe listOf(1, 2, 3)
+      completed shouldBe true
+    }
+
+    @Test
+    fun `block should not execute twice when lifecycle is resumed twice`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      lifecycle.onNextResume { expect(1) }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      expect(2)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      finish(3)
+    }
+
+    @Test
+    fun `block should return value if allowed to complete`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      val result = lifecycle.onNextResume { true }
+
+      result shouldBe true
+    }
+
+    @Test
+    fun `block should return null if not allowed to complete`() = runBlockingTest {
+
+      val lock = Mutex(locked = true)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      val resultDeferred = async {
+        lifecycle.onNextResume {
+          lock.withLock {
+            // unreachable
+            true
+          }
+        }
+      }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      resultDeferred.await() shouldBe null
+    }
+  }
+
+  @Nested
+  inner class `LifecycleOwner version` {
+
+    @Test
+    fun `block should immediately execute if already resumed`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      var executed = false
+
+      launch { lifecycle.onNextResume { executed = true } }
+
+      executed shouldBe true
+    }
+
+    @Test
+    fun `block should not immediately execute if lifecycle is not resumed`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      var executed = false
+
+      val job = launch { lifecycle.onNextResume { executed = true } }
+
+      executed shouldBe false
+
+      job.cancelAndJoin()
+    }
+
+    @Test
+    fun `block should pause when lifecycle is destroyed`() = runBlockingTest {
+
+      val input = Channel<Int>()
+      val output = mutableListOf<Int>()
+      var completed = false
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      launch {
+        lifecycle.onNextResume {
+          input.consumeAsFlow()
+            .onCompletion { completed = true }
+            .collect { output.add(it) }
+        }
+      }
+
+      input.send(1)
+      input.send(2)
+      input.send(3)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      output shouldBe listOf(1, 2, 3)
+      completed shouldBe true
+    }
+
+    @Test
+    fun `block should not execute twice when lifecycle is resumed twice`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      lifecycle.onNextResume { expect(1) }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      expect(2)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      finish(3)
+    }
+
+    @Test
+    fun `block should return value if allowed to complete`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      val result = lifecycle.onNextResume { true }
+
+      result shouldBe true
+    }
+
+    @Test
+    fun `block should return null if not allowed to complete`() = runBlockingTest {
+
+      val lock = Mutex(locked = true)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+      val resultDeferred = async {
+        lifecycle.onNextResume {
+          lock.withLock {
+            // unreachable
+            true
+          }
+        }
+      }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      resultDeferred.await() shouldBe null
+    }
+  }
+}

--- a/android-lifecycle-runtime/src/test/java/dispatch/android/OnNextStartTest.kt
+++ b/android-lifecycle-runtime/src/test/java/dispatch/android/OnNextStartTest.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2020 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package  dispatch.android
+
+import androidx.lifecycle.*
+import dispatch.core.test.*
+import dispatch.internal.test.*
+import io.kotlintest.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.*
+import org.junit.jupiter.api.*
+
+@FlowPreview
+@ExperimentalCoroutinesApi
+class OnNextStartTest : BaseTest(), CoroutineTest {
+
+  override lateinit var testScope: TestProvidedCoroutineScope
+
+  lateinit var lifecycleOwner: LifecycleOwner
+  lateinit var lifecycle: LifecycleRegistry
+
+  @BeforeEach
+  fun beforeEach() {
+
+    lifecycleOwner = LifecycleOwner { lifecycle }
+    lifecycle = LifecycleRegistry(lifecycleOwner)
+  }
+
+  @Nested
+  inner class `Lifecycle version` {
+
+    @Test
+    fun `block should immediately execute if already started`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      var executed = false
+
+      launch { lifecycle.onNextStart { executed = true } }
+
+      executed shouldBe true
+    }
+
+    @Test
+    fun `block should not immediately execute if lifecycle is not started`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      var executed = false
+
+      val job = launch { lifecycle.onNextStart { executed = true } }
+
+      executed shouldBe false
+
+      job.cancelAndJoin()
+    }
+
+    @Test
+    fun `block should stop when lifecycle is destroyed`() = runBlockingTest {
+
+      val input = Channel<Int>()
+      val output = mutableListOf<Int>()
+      var completed = false
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      launch {
+        lifecycle.onNextStart {
+          input.consumeAsFlow()
+            .onCompletion { completed = true }
+            .collect { output.add(it) }
+        }
+      }
+
+      input.send(1)
+      input.send(2)
+      input.send(3)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      output shouldBe listOf(1, 2, 3)
+      completed shouldBe true
+    }
+
+    @Test
+    fun `block should not execute twice when lifecycle is started twice`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      lifecycle.onNextStart { expect(1) }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      expect(2)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      finish(3)
+    }
+
+    @Test
+    fun `block should return value if allowed to complete`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      val result = lifecycle.onNextStart { true }
+
+      result shouldBe true
+    }
+
+    @Test
+    fun `block should return null if not allowed to complete`() = runBlockingTest {
+
+      val lock = Mutex(locked = true)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      val resultDeferred = async {
+        lifecycle.onNextStart {
+          lock.withLock {
+            // unreachable
+            true
+          }
+        }
+      }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      resultDeferred.await() shouldBe null
+    }
+  }
+
+  @Nested
+  inner class `LifecycleOwner version` {
+
+    @Test
+    fun `block should immediately execute if already started`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      var executed = false
+
+      launch { lifecycle.onNextStart { executed = true } }
+
+      executed shouldBe true
+    }
+
+    @Test
+    fun `block should not immediately execute if lifecycle is not started`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      var executed = false
+
+      val job = launch { lifecycle.onNextStart { executed = true } }
+
+      executed shouldBe false
+
+      job.cancelAndJoin()
+    }
+
+    @Test
+    fun `block should stop when lifecycle is destroyed`() = runBlockingTest {
+
+      val input = Channel<Int>()
+      val output = mutableListOf<Int>()
+      var completed = false
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      launch {
+        lifecycle.onNextStart {
+          input.consumeAsFlow()
+            .onCompletion { completed = true }
+            .collect { output.add(it) }
+        }
+      }
+
+      input.send(1)
+      input.send(2)
+      input.send(3)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      output shouldBe listOf(1, 2, 3)
+      completed shouldBe true
+    }
+
+    @Test
+    fun `block should not execute twice when lifecycle is started twice`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      lifecycle.onNextStart { expect(1) }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      expect(2)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      finish(3)
+    }
+
+    @Test
+    fun `block should return value if allowed to complete`() = runBlockingTest {
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      val result = lifecycle.onNextStart { true }
+
+      result shouldBe true
+    }
+
+    @Test
+    fun `block should return null if not allowed to complete`() = runBlockingTest {
+
+      val lock = Mutex(locked = true)
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+      val resultDeferred = async {
+        lifecycle.onNextStart {
+          lock.withLock {
+            // unreachable
+            true
+          }
+        }
+      }
+
+      lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+      resultDeferred.await() shouldBe null
+    }
+  }
+}


### PR DESCRIPTION
Rename the `LifecycleCoroutineScope` functions to `launchEvery__` (`Create` | `Start` | `Resume`) for more explicit meaning.

Add `onNext___` (`Create` | `Start` | `Resume`) suspend functions as extensions for `LifecycleOwner` and `Lifecycle`.