### PR TITLE
Misc cleanup

### DIFF
--- a/dispatch-android-lifecycle-extensions/README.md
+++ b/dispatch-android-lifecycle-extensions/README.md
@@ -51,7 +51,7 @@ class SomeApplication : Application() {
   override fun onCreate() {
     super.onCreate()
     // A custom factory can be set to add elements to the CoroutineContext
-    LifecycleScopeFactory.set { MainImmediateProvidedCoroutineContext() + SomeCustomElement() }
+    LifecycleScopeFactory.set { MainImmediateContext() + SomeCustomElement() }
   }
 }
 ```
@@ -68,7 +68,7 @@ class SomeEspressoTest {
   @After
   fun tearDown() {
     // The factory can also be reset to default
-    LifecycleCoroutineScopeFactory.reset()
+    LifecycleScopeFactory.reset()
   }
 }
 ```
@@ -93,7 +93,7 @@ class SomeFragmentEspressoTest {
   fun setUp() {
     // set a custom factory which is applied to all newly created lifecycleScopes
     LifecycleScopeFactory.set {
-      MainImmediateProvidedCoroutineContext() + idlingRule.dispatcherProvider
+      MainImmediateContext() + idlingRule.dispatcherProvider
     }
 
     // now SomeFragment will use an IdlingDispatcher in its CoroutineScope
@@ -142,7 +142,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.7")
   implementation("com.rickbusarow.dispatch:dispatch-android-lifecycle-extensions:1.0.0-beta04")
-  
+
   implementation("androidx.lifecycle:lifecycle-common:2.2.0")
 }
 ```

--- a/dispatch-android-lifecycle-extensions/samples/src/test/java/samples/LifecycleScopeExtensionSample.kt
+++ b/dispatch-android-lifecycle-extensions/samples/src/test/java/samples/LifecycleScopeExtensionSample.kt
@@ -18,10 +18,10 @@ package samples
 import dispatch.android.lifecycle.*
 import dispatch.core.*
 
-class LifecycleScopeSample {
+class LifecycleScopeExtensionSample {
 
   @Sample
-  fun lifecycleScopeSample() {
+  fun lifecycleScopeExtensionSample() {
 
     // This could be any LifecycleOwner -- Fragments, Activities, Services...
     class SomeFragment : Fragment() {

--- a/dispatch-android-lifecycle-extensions/src/main/java/dispatch/android/lifecycle/lifecycleScope.kt
+++ b/dispatch-android-lifecycle-extensions/src/main/java/dispatch/android/lifecycle/lifecycleScope.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.*
  * The `viewModelScope` is automatically cancelled when the [LifecycleOwner]'s
  * [lifecycle][LifecycleOwner.getLifecycle]'s [Lifecycle.State] drops to [Lifecycle.State.DESTROYED].
  *
- * @sample samples.LifecycleScopeSample.lifecycleScopeSample
+ * @sample samples.LifecycleScopeExtensionSample.lifecycleScopeExtensionSample
  */
 val LifecycleOwner.lifecycleScope: LifecycleCoroutineScope
   get() = LifecycleCoroutineScopeStore.get(this.lifecycle)

--- a/dispatch-android-lifecycle/build.gradle.kts
+++ b/dispatch-android-lifecycle/build.gradle.kts
@@ -78,8 +78,5 @@ dependencies {
   testImplementation(Libs.RickBusarow.Hermit.coroutines)
   testImplementation(Libs.RickBusarow.Hermit.junit5)
 
-  testImplementation(Libs.RickBusarow.Hermit.coroutines)
-  testImplementation(Libs.RickBusarow.Hermit.junit5)
-
   testImplementation(Libs.Robolectric.core)
 }

--- a/dispatch-android-lifecycle/samples/src/test/java/samples/LifecycleCoroutineScopeFactorySample.kt
+++ b/dispatch-android-lifecycle/samples/src/test/java/samples/LifecycleCoroutineScopeFactorySample.kt
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package samples
 
 import dispatch.android.lifecycle.*
@@ -46,7 +44,8 @@ class LifecycleCoroutineScopeFactorySample {
   }
 }
 
-private annotation class Before
-private annotation class After
-private annotation class Module
-private annotation class Provides
+internal annotation class Before
+internal annotation class After
+internal annotation class Module
+internal annotation class Provides
+internal annotation class Inject

--- a/dispatch-android-lifecycle/samples/src/test/java/samples/LifecycleCoroutineScopeSample.kt
+++ b/dispatch-android-lifecycle/samples/src/test/java/samples/LifecycleCoroutineScopeSample.kt
@@ -24,8 +24,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.*
 
-annotation class Inject
-
 @CoroutineTest
 @ExperimentalCoroutinesApi
 class LifecycleCoroutineScopeSample(

--- a/dispatch-core/src/main/java/dispatch/core/CoroutineScopes.kt
+++ b/dispatch-core/src/main/java/dispatch/core/CoroutineScopes.kt
@@ -151,8 +151,8 @@ public fun MainCoroutineScope(
  * @see CoroutineScope
  */
 public fun MainImmediateCoroutineScope(
-  job: Job = SupervisorJob(), dispatcherProvider:
-  DispatcherProvider = DefaultDispatcherProvider()
+  job: Job = SupervisorJob(),
+  dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()
 ): MainImmediateCoroutineScope = object : MainImmediateCoroutineScope {
   override val coroutineContext = job + dispatcherProvider.mainImmediate +
       dispatcherProvider

--- a/docs/kdoc/dispatch-android-lifecycle-extensions/index.md
+++ b/docs/kdoc/dispatch-android-lifecycle-extensions/index.md
@@ -48,7 +48,7 @@ class SomeApplication : Application() {
   override fun onCreate() {
     super.onCreate()
     // A custom factory can be set to add elements to the CoroutineContext
-    LifecycleScopeFactory.set { MainImmediateProvidedCoroutineContext() + SomeCustomElement() }
+    LifecycleScopeFactory.set { MainImmediateContext() + SomeCustomElement() }
   }
 }
 ```
@@ -90,7 +90,7 @@ class SomeFragmentEspressoTest {
   fun setUp() {
     // set a custom factory which is applied to all newly created lifecycleScopes
     LifecycleScopeFactory.set {
-      MainImmediateProvidedCoroutineContext() + idlingRule.dispatcherProvider
+      MainImmediateContext() + idlingRule.dispatcherProvider
     }
 
     // now SomeFragment will use an IdlingDispatcher in its CoroutineScope
@@ -139,7 +139,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.7")
   implementation("com.rickbusarow.dispatch:dispatch-android-lifecycle-extensions:1.0.0-beta04")
-  
+
   implementation("androidx.lifecycle:lifecycle-common:2.2.0")
 }
 ```

--- a/docs/kdoc/dispatch-android-lifecycle-extensions/index.md
+++ b/docs/kdoc/dispatch-android-lifecycle-extensions/index.md
@@ -65,7 +65,7 @@ class SomeEspressoTest {
   @After
   fun tearDown() {
     // The factory can also be reset to default
-    LifecycleCoroutineScopeFactory.reset()
+    LifecycleScopeFactory.reset()
   }
 }
 ```

--- a/docs/modules/dispatch-android-lifecycle-extensions.md
+++ b/docs/modules/dispatch-android-lifecycle-extensions.md
@@ -51,7 +51,7 @@ class SomeApplication : Application() {
   override fun onCreate() {
     super.onCreate()
     // A custom factory can be set to add elements to the CoroutineContext
-    LifecycleScopeFactory.set { MainImmediateProvidedCoroutineContext() + SomeCustomElement() }
+    LifecycleScopeFactory.set { MainImmediateContext() + SomeCustomElement() }
   }
 }
 ```
@@ -93,7 +93,7 @@ class SomeFragmentEspressoTest {
   fun setUp() {
     // set a custom factory which is applied to all newly created lifecycleScopes
     LifecycleScopeFactory.set {
-      MainImmediateProvidedCoroutineContext() + idlingRule.dispatcherProvider
+      MainImmediateContext() + idlingRule.dispatcherProvider
     }
 
     // now SomeFragment will use an IdlingDispatcher in its CoroutineScope
@@ -142,7 +142,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.7")
   implementation("com.rickbusarow.dispatch:dispatch-android-lifecycle-extensions:1.0.0-beta04")
-  
+
   implementation("androidx.lifecycle:lifecycle-common:2.2.0")
 }
 ```

--- a/docs/modules/dispatch-android-lifecycle-extensions.md
+++ b/docs/modules/dispatch-android-lifecycle-extensions.md
@@ -68,7 +68,7 @@ class SomeEspressoTest {
   @After
   fun tearDown() {
     // The factory can also be reset to default
-    LifecycleCoroutineScopeFactory.reset()
+    LifecycleScopeFactory.reset()
   }
 }
 ```


### PR DESCRIPTION
- clean up readme examples of `LifecycleScopeFactory` which incorrectly call it `LifecycleCoroutineScopeFactory`
- remove duplicate dependency declarations in the `:dispatch-android-lifecycle` build.gradle.kts
- consolidate location and visibility of fake annotations in the `:dispatch-android-lifecycle` sample code
- rename the `lifecycleScope` sample file, class, and function in `:dispatch-android-lifecycle-extensions` to `LifecycleScopeExtensionSample` to remove confusion with the non-extension variant.
- fix formatting of the parameters in the `MainImmediateCoroutineScope` factory function.
