### PR TITLE
update Detekt to 1.4.2

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -149,11 +149,7 @@ object Libs {
   }
 
   object Detekt {
-    /*
-    TODO - When updating, check to see if Spek and AssertJ can be removed from :detekt:extensions
-    https://github.com/detekt/detekt/issues/3082
-     */
-    const val version = "1.14.1"
+    const val version = "1.14.2"
     const val api = "io.gitlab.arturbosch.detekt:detekt-api:$version"
     const val cli = "io.gitlab.arturbosch.detekt:detekt-cli:$version"
     const val formatting = "io.gitlab.arturbosch.detekt:detekt-formatting:$version"

--- a/dispatch-detekt/build.gradle.kts
+++ b/dispatch-detekt/build.gradle.kts
@@ -24,11 +24,6 @@ dependencies {
   api(Libs.Detekt.api)
   api(Libs.Kotlin.compiler)
 
-  // detekt-test leaks transitive dependencies upon AssertJ and Spek
-  // https://github.com/detekt/detekt/issues/3082
-  testImplementation("org.assertj:assertj-core:3.17.2")
-  testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.13")
-
   testImplementation(Libs.Detekt.api)
   testImplementation(Libs.Detekt.test)
   testImplementation(Libs.JUnit.jUnit5Api)


### PR DESCRIPTION
https://github.com/detekt/detekt/releases/tag/v1.14.2