### PR TITLE
set min and target jvm to 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,17 @@ subprojects {
   }
 }
 
+allprojects {
+  // force Java 8 source when building java-only artifacts.  This is different than the Kotlin jvm target.
+  pluginManager.withPlugin("java") {
+    configure<JavaPluginExtension> {
+      sourceCompatibility = JavaVersion.VERSION_1_8
+      targetCompatibility = JavaVersion.VERSION_1_8
+    }
+  }
+}
+
+
 subprojects {
   tasks.withType<KotlinCompile>()
     .configureEach {


### PR DESCRIPTION
This was always automatic in the past since I was on machines running java 8.  Never noticed I hadn't explicitly set it. =/