### PR TITLE
disable gradle caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses : actions/setup-java@v2
-        with :
-          distribution : 'temurin'
-          java-version : '11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
           cache: 'gradle'
 
-      - uses: burrunan/gradle-cache-action@v1
-        name: detekt
-        with:
-          gradle-dependencies-cache-key: |
-            gradle/libs.versions.toml
-          arguments: |
-            detekt --no-daemon
-          concurrent: true
-          gradle-build-scan-report: false
-          gradle-distribution-sha-256-sum-warning: false
+      - name: detekt
+        run: ./gradlew detekt --no-daemon
 
   ktlint:
 
@@ -57,37 +49,40 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
 
     steps:
-      - uses: actions/checkout@v2
+      - name: check out with token (used by forks)
+        uses: actions/checkout@v3
+        if: github.event.pull_request.head.repo.full_name != github.repository
+
+      - name: check out with PAT (used by main repo)
+        uses: actions/checkout@v3
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
 
       - name: Set up JDK
-        uses : actions/setup-java@v2
-        with :
-          distribution : 'temurin'
-          java-version : '11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
           cache: 'gradle'
 
-      # formats all src files
-      - uses: burrunan/gradle-cache-action@v1
-        name: KtLint format
-        with:
-          gradle-dependencies-cache-key: |
-            gradle/libs.versions.toml
-          arguments: |
-            ktlintFormat
-          concurrent: true
-          gradle-build-scan-report: false
-          gradle-distribution-sha-256-sum-warning: false
+      - name: KtLint format (used by main repo)
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: ./gradlew ktlintformat -q --no-daemon
 
       # If KtLint generated changes, commit and push those changes.
-      - name: commit changes
+      - name: commit changes (used by main repo)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Apply KtLint format
           commit_options: '--no-verify --signoff'
+
+      - name: KtLint check (used by forks)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: ./gradlew ktlintCheck -q --no-daemon
 
 #  versioning:
 #
@@ -155,22 +150,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses : actions/setup-java@v2
-        with :
-          distribution : 'temurin'
-          java-version : '11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
           cache: 'gradle'
 
-      - uses: burrunan/gradle-cache-action@v1
-        name: api check
-        with:
-          gradle-dependencies-cache-key: |
-            gradle/libs.versions.toml
-          arguments: |
-            apicheck
-          concurrent: true
-          gradle-build-scan-report: false
-          gradle-distribution-sha-256-sum-warning: false
+      - name: api check
+        run: ./gradlew apicheck --no-daemon
 
   dependency-guard:
 
@@ -191,16 +178,8 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - uses: burrunan/gradle-cache-action@v1
-        name: dependency-guard
-        with:
-          gradle-dependencies-cache-key: |
-            gradle/libs.versions.toml
-          arguments: |
-            dependencyGuard
-          concurrent: true
-          gradle-build-scan-report: false
-          gradle-distribution-sha-256-sum-warning: false
+      - name: dependency-guard
+        run: ./gradlew dependencyGuard --no-daemon --refresh-dependencies
 
   tests:
 
@@ -214,19 +193,26 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses : actions/setup-java@v2
-        with :
-          distribution : 'temurin'
-          java-version : '11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
           cache: 'gradle'
 
-      - uses: burrunan/gradle-cache-action@v1
-        name: all tests
+      - name: all tests
+        run: ./gradlew testJvm --no-daemon
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v3
+        if: failure()
         with:
-          gradle-dependencies-cache-key: |
-            gradle/libs.versions.toml
-          arguments: |
-            testJvm
-          concurrent: true
-          gradle-build-scan-report: false
-          gradle-distribution-sha-256-sum-warning: false
+          name: test-results-ubuntu
+          path: ./**/build/reports/tests/
+
+      - name: Unit test results
+        uses: mikepenz/action-junit-report@v3
+        if: failure()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/build/**/TEST-*.xml'
+          check_name: Unit Test Results - Ubuntu


### PR DESCRIPTION
The free storage is just far too prone to rate limiting.  Any burst of activity like Renovate PRs is guaranteed to just make everything fail.