### PR TITLE
behavior change -- make the `async_`/`launch_`/`with_` builders use the post-fold DispatcherProvider

### DIFF
--- a/dispatch-core/build.gradle.kts
+++ b/dispatch-core/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
   testImplementation(libs.junit.jupiter)
   testImplementation(libs.kotest.assertions)
   testImplementation(libs.kotest.properties)
-  testImplementation(libs.kotest.runner)
   testImplementation(libs.kotlin.test.common)
   testImplementation(libs.kotlin.test.core)
   testImplementation(libs.kotlinx.coroutines.test)

--- a/dispatch-core/src/main/java/dispatch/core/Async.kt
+++ b/dispatch-core/src/main/java/dispatch/core/Async.kt
@@ -28,12 +28,16 @@ import kotlin.coroutines.EmptyCoroutineContext
 /**
  * Creates a coroutine and returns its future result as an implementation of [Deferred].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its **default**
- * [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.default`) to call
- * `async(...)`.
+ * Uses the [default][DispatcherProvider.default] [dispatcher][CoroutineDispatcher].
  *
- * The `default` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.AsyncSample.asyncDefaultSample
  * @see async
@@ -42,15 +46,21 @@ public fun <T> CoroutineScope.asyncDefault(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> T
-): Deferred<T> = async(context + coroutineContext.dispatcherProvider.default, start, block)
+): Deferred<T> = async(context + getProvider(context).default, start, block)
 
 /**
  * Creates a coroutine and returns its future result as an implementation of [Deferred].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its **io**
- * [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.io`) to call `async(...)`.
+ * Uses the [io][DispatcherProvider.io] [dispatcher][CoroutineDispatcher].
  *
- * The `io` property always corresponds to the `DispatcherProvider` of the current `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.AsyncSample.asyncIOSample
  * @see async
@@ -59,16 +69,21 @@ public fun <T> CoroutineScope.asyncIO(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> T
-): Deferred<T> = async(context + coroutineContext.dispatcherProvider.io, start, block)
+): Deferred<T> = async(context + getProvider(context).io, start, block)
 
 /**
  * Creates a coroutine and returns its future result as an implementation of [Deferred].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its **main**
- * [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.main`) to call `async(...)`.
+ * Uses the [main][DispatcherProvider.main] [dispatcher][CoroutineDispatcher].
  *
- * The `main` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.AsyncSample.asyncMainSample
  * @see async
@@ -77,17 +92,21 @@ public fun <T> CoroutineScope.asyncMain(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> T
-): Deferred<T> = async(context + coroutineContext.dispatcherProvider.main, start, block)
+): Deferred<T> = async(context + getProvider(context).main, start, block)
 
 /**
  * Creates a coroutine and returns its future result as an implementation of [Deferred].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver,
- * then uses its **mainImmediate** [CoroutineDispatcher] property
- * (`coroutineContext.dispatcherProvider.mainImmediate`) to call `async(...)`.
+ * Uses the [mainImmediate][DispatcherProvider.mainImmediate] [dispatcher][CoroutineDispatcher].
  *
- * The `mainImmediate` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.AsyncSample.asyncMainImmediateSample
  * @see async
@@ -96,17 +115,21 @@ public fun <T> CoroutineScope.asyncMainImmediate(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> T
-): Deferred<T> = async(context + coroutineContext.dispatcherProvider.mainImmediate, start, block)
+): Deferred<T> = async(context + getProvider(context).mainImmediate, start, block)
 
 /**
  * Creates a coroutine and returns its future result as an implementation of [Deferred].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its
- * **unconfined** [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.unconfined`)
- * to call `async(...)`.
+ * Uses the [unconfined][DispatcherProvider.unconfined] [dispatcher][CoroutineDispatcher].
  *
- * The `unconfined` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.AsyncSample.asyncUnconfinedSample
  * @see async
@@ -115,4 +138,4 @@ public fun <T> CoroutineScope.asyncUnconfined(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> T
-): Deferred<T> = async(context + coroutineContext.dispatcherProvider.unconfined, start, block)
+): Deferred<T> = async(context + getProvider(context).unconfined, start, block)

--- a/dispatch-core/src/main/java/dispatch/core/Launch.kt
+++ b/dispatch-core/src/main/java/dispatch/core/Launch.kt
@@ -28,12 +28,16 @@ import kotlin.coroutines.EmptyCoroutineContext
  * to the coroutine as a [Job]. The coroutine is cancelled when the resulting job is
  * [cancelled][Job.cancel].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its **default**
- * [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.default`) to call
- * `launch(...)`.
+ * Uses the [default][DispatcherProvider.default] [dispatcher][CoroutineDispatcher].
  *
- * The `default` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.LaunchSample.launchDefaultSample
  * @see launch
@@ -42,17 +46,23 @@ public fun CoroutineScope.launchDefault(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> Unit
-): Job = launch(context + coroutineContext.dispatcherProvider.default, start, block)
+): Job = launch(context + getProvider(context).default, start, block)
 
 /**
  * Launches a new coroutine without blocking the current thread and returns a reference
  * to the coroutine as a [Job]. The coroutine is cancelled when the resulting job is
  * [cancelled][Job.cancel].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its **io**
- * [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.io`) to call `launch(...)`.
+ * Uses the [io][DispatcherProvider.io] [dispatcher][CoroutineDispatcher].
  *
- * The `io` property always corresponds to the `DispatcherProvider` of the current `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.LaunchSample.launchIOSample
  * @see launch
@@ -61,19 +71,23 @@ public fun CoroutineScope.launchIO(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> Unit
-): Job = launch(context + coroutineContext.dispatcherProvider.io, start, block)
+): Job = launch(context + getProvider(context).io, start, block)
 
 /**
  * Launches a new coroutine without blocking the current thread and returns a reference
  * to the coroutine as a [Job]. The coroutine is cancelled when the resulting job is
  * [cancelled][Job.cancel].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its **main**
- * [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.main`) to call
- * `launch(...)`.
+ * Uses the [main][DispatcherProvider.main] [dispatcher][CoroutineDispatcher].
  *
- * The `main` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.LaunchSample.launchMainSample
  * @see launch
@@ -82,19 +96,23 @@ public fun CoroutineScope.launchMain(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> Unit
-): Job = launch(context + coroutineContext.dispatcherProvider.main, start, block)
+): Job = launch(context + getProvider(context).main, start, block)
 
 /**
  * Launches a new coroutine without blocking the current thread and returns a reference
  * to the coroutine as a [Job]. The coroutine is cancelled when the resulting job is
  * [cancelled][Job.cancel].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver,
- * then uses its **mainImmediate** [CoroutineDispatcher] property
- * (`coroutineContext.dispatcherProvider.mainImmediate`) to call `launch(...)`.
+ * Uses the [mainImmediate][DispatcherProvider.mainImmediate] [dispatcher][CoroutineDispatcher].
  *
- * The `mainImmediate` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.LaunchSample.launchMainImmediateSample
  * @see launch
@@ -103,19 +121,23 @@ public fun CoroutineScope.launchMainImmediate(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> Unit
-): Job = launch(context + coroutineContext.dispatcherProvider.mainImmediate, start, block)
+): Job = launch(context + getProvider(context).mainImmediate, start, block)
 
 /**
  * Launches a new coroutine without blocking the current thread and returns a reference
  * to the coroutine as a [Job]. The coroutine is cancelled when the resulting job is
  * [cancelled][Job.cancel].
  *
- * Extracts the [DispatcherProvider] from the [CoroutineScope] receiver, then uses its
- * **unconfined** [CoroutineDispatcher] property (`coroutineContext.dispatcherProvider.unconfined`)
- * to call `launch(...)`.
+ * Uses the [unconfined][DispatcherProvider.unconfined] [dispatcher][CoroutineDispatcher].
  *
- * The `unconfined` property always corresponds to the `DispatcherProvider` of the current
- * `CoroutineScope`.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.LaunchSample.launchUnconfinedSample
  * @see launch
@@ -124,4 +146,8 @@ public fun CoroutineScope.launchUnconfined(
   context: CoroutineContext = EmptyCoroutineContext,
   start: CoroutineStart = CoroutineStart.DEFAULT,
   block: suspend CoroutineScope.() -> Unit
-): Job = launch(context + coroutineContext.dispatcherProvider.unconfined, start, block)
+): Job = launch(context + getProvider(context).unconfined, start, block)
+
+internal fun CoroutineScope.getProvider(
+  context: CoroutineContext
+): DispatcherProvider = context[DispatcherProvider] ?: coroutineContext.dispatcherProvider

--- a/dispatch-core/src/main/java/dispatch/core/Suspend.kt
+++ b/dispatch-core/src/main/java/dispatch/core/Suspend.kt
@@ -17,20 +17,25 @@ package dispatch.core
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.coroutines.coroutineContext
 
 /**
  * Calls the specified suspending block with a given coroutine context, suspends until it completes,
  * and returns the result.
  *
- * Extracts the [DispatcherProvider] from the `coroutineContext` of the current coroutine, then uses
- * its **default** [CoroutineDispatcher] property to call `withContext(theDispatcher)`, and returns
- * the result.
+ * Uses the [default][DispatcherProvider.default] [dispatcher][CoroutineDispatcher].
  *
- * The *default* property always corresponds to the `DispatcherProvider` of the current coroutine.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.WithContextSample.withDefaultSample
  * @see withContext
@@ -39,7 +44,7 @@ public suspend fun <T> withDefault(
   context: CoroutineContext = EmptyCoroutineContext,
   block: suspend CoroutineScope.() -> T
 ): T {
-  val newContext = context + coroutineContext.dispatcherProvider.default
+  val newContext = context + getProvider(context).default
   return withContext(newContext, block)
 }
 
@@ -47,11 +52,16 @@ public suspend fun <T> withDefault(
  * Calls the specified suspending block with a given coroutine context, suspends until it completes,
  * and returns the result.
  *
- * Extracts the [DispatcherProvider] from the `coroutineContext` of the current coroutine, then uses
- * its **io** [CoroutineDispatcher] property to call `withContext(theDispatcher)`, and returns the
- * result.
+ * Uses the [io][DispatcherProvider.io] [dispatcher][CoroutineDispatcher].
  *
- * The `io` property always corresponds to the `DispatcherProvider` of the current coroutine.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.WithContextSample.withIOSample
  * @see withContext
@@ -60,7 +70,7 @@ public suspend fun <T> withIO(
   context: CoroutineContext = EmptyCoroutineContext,
   block: suspend CoroutineScope.() -> T
 ): T {
-  val newContext = context + coroutineContext.dispatcherProvider.io
+  val newContext = context + getProvider(context).io
   return withContext(newContext, block)
 }
 
@@ -68,11 +78,16 @@ public suspend fun <T> withIO(
  * Calls the specified suspending block with a given coroutine context, suspends until it completes,
  * and returns the result.
  *
- * Extracts the [DispatcherProvider] from the `coroutineContext` of the current coroutine, then uses
- * its **main** [CoroutineDispatcher] property to call `withContext(theDispatcher)`, and returns the
- * result.
+ * Uses the [main][DispatcherProvider.main] [dispatcher][CoroutineDispatcher].
  *
- * The `main` property always corresponds to the `DispatcherProvider` of the current coroutine.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.WithContextSample.withMainSample
  * @see withContext
@@ -81,7 +96,7 @@ public suspend fun <T> withMain(
   context: CoroutineContext = EmptyCoroutineContext,
   block: suspend CoroutineScope.() -> T
 ): T {
-  val newContext = context + coroutineContext.dispatcherProvider.main
+  val newContext = context + getProvider(context).main
   return withContext(newContext, block)
 }
 
@@ -89,12 +104,16 @@ public suspend fun <T> withMain(
  * Calls the specified suspending block with a given coroutine context, suspends until it completes,
  * and returns the result.
  *
- * Extracts the [DispatcherProvider] from the `coroutineContext` of the current coroutine, then uses
- * its **mainImmediate** [CoroutineDispatcher] property to call `withContext(theDispatcher)`, and
- * returns the result.
+ * Uses the [mainImmediate][DispatcherProvider.mainImmediate] [dispatcher][CoroutineDispatcher].
  *
- * The `mainImmediate` property always corresponds to the `DispatcherProvider` of the current
- * coroutine.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.WithContextSample.withMainImmediateSample
  * @see withContext
@@ -103,7 +122,7 @@ public suspend fun <T> withMainImmediate(
   context: CoroutineContext = EmptyCoroutineContext,
   block: suspend CoroutineScope.() -> T
 ): T {
-  val newContext = context + coroutineContext.dispatcherProvider.mainImmediate
+  val newContext = context + getProvider(context).mainImmediate
   return withContext(newContext, block)
 }
 
@@ -111,12 +130,16 @@ public suspend fun <T> withMainImmediate(
  * Calls the specified suspending block with a given coroutine context, suspends until it completes,
  * and returns the result.
  *
- * Extracts the [DispatcherProvider] from the `coroutineContext` of the current coroutine, then
- * uses its **unconfined** [CoroutineDispatcher] property to call `withContext(theDispatcher)`, and
- * returns the result.
+ * Uses the [unconfined][DispatcherProvider.unconfined] [dispatcher][CoroutineDispatcher].
  *
- * The `unconfined` property always corresponds to the `DispatcherProvider` of the current
- * coroutine.
+ * The specific `dispatcherProvider` instance to be used is determined *after* the [context]
+ * parameter has been [folded][CoroutineContext.fold] into the receiver's context.
+ *
+ * The selected [DispatcherProvider] is essentially the first non-null result from:
+ * - the [context] parameter
+ * - the receiver [CoroutineScope]'s [coroutineContext][CoroutineScope.coroutineContext]
+ * - [DefaultDispatcherProvider.get] Extracts the [DispatcherProvider] from the [CoroutineScope]
+ *   receiver
  *
  * @sample dispatch.core.samples.WithContextSample.withUnconfinedSample
  * @see withContext
@@ -125,6 +148,11 @@ public suspend fun <T> withUnconfined(
   context: CoroutineContext = EmptyCoroutineContext,
   block: suspend CoroutineScope.() -> T
 ): T {
-  val newContext = context + coroutineContext.dispatcherProvider.unconfined
+  val newContext = context + getProvider(context).unconfined
   return withContext(newContext, block)
 }
+
+internal suspend fun getProvider(
+  newContext: CoroutineContext
+): DispatcherProvider = newContext[DispatcherProvider]
+  ?: currentCoroutineContext().dispatcherProvider


### PR DESCRIPTION
This is technically a breaking change.

Consider this example:

```kotlin
val provider1 = DispatcherProvider(default = NamedDispatcher(name = "1"), /*...*/)
val provider2 = DispatcherProvider(default = NamedDispatcher(name = "2"), /*...*/)

val scope = CoroutineScope(provider1)

scope.launchDefault(provider2) {
  // this behavior is unchanged
  assert(coroutineContext[DispatcherProvider] == provider2)

  // this behavior changed
  //   old output:  NamedDispatcher("1")
  //   new output:  NamedDispatcher("2")
  println(coroutineContext[ContinuationInterceptor])
}
```

The behavior will change if a coroutine is being built while passing in a new DispatcherProvider into the builder function, AND that builder is accessing a DispatcherProvider property which is different with that new instance.

This change comes because it's consistent with how kotlinx-coroutines handles the merging of `context` parameters.  The coroutine is built using the same context that it exposes in the `currentCoroutineContext()` extension or `coroutineContext` property.