### PR TITLE
Count dispatch time as not idle

### DIFF
--- a/dispatch-android-espresso/src/main/java/dispatch/android/espresso/IdlingDispatcher.kt
+++ b/dispatch-android-espresso/src/main/java/dispatch/android/espresso/IdlingDispatcher.kt
@@ -53,9 +53,9 @@ public class IdlingDispatcher(
    * suspension.
    */
   override fun dispatch(context: CoroutineContext, block: Runnable) {
-
+    counter.increment()
+    
     val runnable = Runnable {
-      counter.increment()
       try {
         block.run()
       } finally {


### PR DESCRIPTION
When coroutine is dispatched, depending on the dispatcher, it might take some time for it to actually start executing.

In current state, this time is not count as non-idle, which can result in flaky tests.

This PR fixes this.